### PR TITLE
Migrate to jdbc.next

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       CIRCLE: "yep"
       PG_USER: utility_belt
       PG_PASSWORD: password
-      PG_DB: utility_belt
+      PG_DB: utility_belt_test
       PG_HOST: localhost
       PG_PORT: 5432
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Consist of:
 
 Built on top of:
 
+- [JDBC.next](https://github.com/seancorfield/next-jdbc)
 - [Cheshire](https://github.com/dakrone/cheshire) for JSON
 - [HugSQL](https://www.hugsql.org) for SQL queries
 - [clj-time](https://github.com/clj-time/clj-time) for datetime handling
@@ -71,6 +72,15 @@ Dependencies, in `:dev` profile:
                    :dependencies [[com.h2database/h2 "1.4.196"]]}}
 ```
 
+## Testing this library
+
+All tests require a real Postgres instance. You can start it locally via Docker, by running:
+
+```
+./script/start-test-postgres
+```
+
+It will setup a Postgres 9.6 instance, running on port 5434.
 
 ## Defining SQL queries and functions
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Consist of:
 
 Built on top of:
 
-- [JDBC.next](https://github.com/seancorfield/next-jdbc)
+- [next.jdbc](https://github.com/seancorfield/next-jdbc)
 - [Cheshire](https://github.com/dakrone/cheshire) for JSON
 - [HugSQL](https://www.hugsql.org) for SQL queries
 - [clj-time](https://github.com/clj-time/clj-time) for datetime handling
@@ -52,9 +52,9 @@ Postgres configuration, with [Aero](https://github.com/juxt/aero):
 
 ```
 
+## Coercions and JSONB
 
-
-Note: `utility-belt.sql` comes with all required dependencies for communication with Postgres (including a connection pool, PG adapter and SQL query interface).
+`utility-belt.sql` comes with all required dependencies for communication with Postgres (including a connection pool, PG adapter and SQL query interface) as wells as necessary coercion setup for Joda DateTime (via `clj-time`) JSONB data type. To enable these coercions require `utility-belt.sql.conv` namespace.
 
 
 ### Tests
@@ -81,6 +81,8 @@ Dependencies, in `:dev` Lein profile:
 
 We're using [HugSQL](https://hugsql.org) for defining SQL queries and turning them into functions.
 
+> 🙋 **Note** by default, `load-sql-file` uses backwards compatible mode, and will use lower-case, unqualified keywords when mapping column names in result sets.
+
 `utility-belt.sql.model` namespace provides a helper which makes it easy to load these SQL files:
 
 file: `some.model.sql`
@@ -102,6 +104,12 @@ file: `some_model.clj`
 
 ;; will pull in `get-all*` into current ns
 ```
+
+
+By convention, it's best to add `*` suffix to queries defined in the SQL file, and create corresponding function in the Clojure file loading it. E.g.
+
+SQL file function: `get-all*`
+Clojure file function, `get-all`, calls `get-all*`
 
 ###  Debugging queries
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Built on top of:
 
 Mostly used with Postgres and H2, but should work with anything that's supported by JDBC.
 
-## Usage
+## Connection pool component
 
 
 ```clojure
@@ -30,7 +30,22 @@ Mostly used with Postgres and H2, but should work with anything that's supported
   (component/start (utility-belt.sql.component.connection-pool/create config))
 ```
 
-Then use can use the running component as an argument passed to HugSQL functions or as the connection to `clojure.tools.jdbc`
+Then use can use the running component as an argument passed to HugSQL functions or as the connection to `nextjdbc` functions.
+
+### Usage with Ragtime
+
+[Ragtime](https://github.com/weavejester/ragtime) is a simple migration library, which provides support for SQL migrations via [ragtime.jdbc].
+To run migrations with the connection pool component, you need to use older, `clojure.java.jdbc` format of passing the connection:
+
+
+```clojure
+(require '[ragtime.repl :as repl]
+         '[ragtime.jdbc :as jdbc])
+
+(repl/migrate {:datastore (jdbc/sql-database {:datasource (:pool connection-component)})
+               :migrations (jdbc/load-resources "migrations")})
+
+```
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -34,15 +34,14 @@ Then use can use the running component as an argument passed to HugSQL functions
 
 ### Usage with Ragtime
 
-[Ragtime](https://github.com/weavejester/ragtime) is a simple migration library, which provides support for SQL migrations via [ragtime.jdbc].
-To run migrations with the connection pool component, you need to use older, `clojure.java.jdbc` format of passing the connection:
+[Ragtime](https://github.com/weavejester/ragtime) is a simple migration library, which provides support for SQL migrations via `ragtime.jdbc`.
 
 
 ```clojure
 (require '[ragtime.repl :as repl]
          '[ragtime.jdbc :as jdbc])
 
-(repl/migrate {:datastore (jdbc/sql-database {:datasource (:pool connection-component)})
+(repl/migrate {:datastore (jdbc/sql-database connection-pool)
                :migrations (jdbc/load-resources "migrations")})
 
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Mostly used with Postgres and H2, but should work with anything that's supported
   (component/start (utility-belt.sql.component.connection-pool/create config))
 ```
 
-Then use can use the running component as an argument passed to HugSQL functions or as the connection to `nextjdbc` functions.
+Then use can use the running component as an argument passed to HugSQL functions or as the connection to `next.jdbc` functions.
 
 ### Usage with Ragtime
 
@@ -46,9 +46,9 @@ Then use can use the running component as an argument passed to HugSQL functions
 
 ```
 
-## Configuration
+### Configuration
 
-### Production
+#### Production
 
 Postgres configuration, with [Aero](https://github.com/juxt/aero):
 
@@ -95,7 +95,8 @@ Dependencies, in `:dev` Lein profile:
 
 We're using [HugSQL](https://hugsql.org) for defining SQL queries and turning them into functions.
 
-> 🙋 **Note** by default, `load-sql-file` uses backwards compatible mode, and will use lower-case, unqualified keywords when mapping column names in result sets.
+
+> 🙋 **Note** by default, `load-sql-file` uses backwards compatible mode, and will use lower-case, unqualified keywords when mapping column names in result sets. Read more about **modes** below
 
 `utility-belt.sql.model` namespace provides a helper which makes it easy to load these SQL files:
 
@@ -125,6 +126,21 @@ By convention, it's best to add `*` suffix to queries defined in the SQL file, a
 SQL file function: `get-all*`
 Clojure file function, `get-all`, calls `get-all*`
 
+### Modes
+
+You can choose the mode of the column to hash key conversion when defining a model namespace:
+
+```clojure
+(sql.model/load-sql-file "app/some/model.sql" {:mode MODE})
+```
+
+Available modes:
+
+- `:java.jdbc` - lower case, unqalified keys
+- `:next.jdbc` - maps with qualified keys
+- `kebab-maps` - lower case, unqalified keys, `kebab-case`
+
+
 ###  Debugging queries
 
 HugSQL has a handy functionality of creating functions returning
@@ -145,6 +161,19 @@ useful for debugging:
 [ "SELECT * from some_table where team_uuid = ? ", "abcdef"]
 
 ```
+
+## Helpers
+
+Helpers are simple wrappers around basic JDBC functionality, they are provided so that consumers of the library can roll with latest versions without worrying whether `clojure.java.jdbc` or `jdbc.next` (or some other adapter) is used.
+
+#### `with-transaction`
+
+Wrapper around `next.jdbc/with-trasnaction` macro
+
+
+#### `execute`
+
+Wrapper around `next.jdbc/execute!` but also supports the same modes of converting column names to hash map keys.
 
 # Authors
 

--- a/dev-resources/logback.xml
+++ b/dev-resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>date=%date level=%level thread=%thread ns=%logger message=%msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/project.clj
+++ b/project.clj
@@ -8,12 +8,12 @@
   :warn-on-reflection true
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.postgresql/postgresql "42.2.9"]
-                 [seancorfield/next.jdbc "1.0.11"]
+                 [seancorfield/next.jdbc "1.0.13"]
                  [cheshire "5.9.0"]
                  [clj-time "0.15.2"]
                  [com.layerware/hugsql "0.5.1"]
-                 [com.layerware/hugsql-adapter-next-jdbc "0.5.1"]
-                 [hikari-cp "2.9.0"]]
+                 [com.layerware/hugsql-adapter-next-jdbc "0.5.1" :exclusions [seancorfield/next.jdbc]]
+                 [hikari-cp "2.10.0"]]
   :plugins [[lein-cloverage "1.1.1" :exclusions [org.clojure/clojure]]]
   :profiles {:dev
              {:dependencies [[org.clojure/tools.logging "0.5.0"]

--- a/project.clj
+++ b/project.clj
@@ -17,4 +17,5 @@
   :plugins [[lein-cloverage "1.1.1" :exclusions [org.clojure/clojure]]]
   :profiles {:dev
              {:dependencies [[org.clojure/tools.logging "0.5.0"]
+                             [ch.qos.logback/logback-classic "1.2.3"]
                              [com.stuartsierra/component "0.4.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nomnom/utility-belt.sql "0.3.1-SNAPSHOT"
+(defproject nomnom/utility-belt.sql "1.0.0-SNAPSHOT"
   :description "Tools for working with Postgres (queries, connection pool component, helpers etc)"
   :url "https://github.com/nomnom-insights/nomnom.utility-belt.sql"
   :deploy-repositories {"clojars" {:sign-releases false

--- a/project.clj
+++ b/project.clj
@@ -1,16 +1,18 @@
-(defproject nomnom/utility-belt.sql "0.2.2"
+(defproject nomnom/utility-belt.sql "0.3.0-SNAPSHOT"
   :description "Tools for working with Postgres (queries, connection pool component, helpers etc)"
   :url "https://github.com/nomnom-insights/nomnom.utility-belt.sql"
   :deploy-repositories {"clojars" {:sign-releases false
-                                   :username [:gpg :env/clojars_username]
-                                   :password [:gpg :env/clojars_password]}}
+                                   :username :env/clojars_username
+                                   :password :env/clojars_password}}
 
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.postgresql/postgresql "42.2.8"]
-                 [org.clojure/java.jdbc "0.7.10"]
+                 [seancorfield/next.jdbc "1.0.10"]
+
                  [cheshire "5.9.0"]
                  [clj-time "0.15.2"]
                  [com.layerware/hugsql "0.5.1"]
+                 [com.layerware/hugsql-adapter-next-jdbc "0.5.1"]
                  [hikari-cp "2.9.0"]]
   :plugins [[lein-cloverage "1.1.1" :exclusions [org.clojure/clojure]]]
   :profiles {:dev

--- a/project.clj
+++ b/project.clj
@@ -6,8 +6,8 @@
                                    :password :env/clojars_password}}
 
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.postgresql/postgresql "42.2.8"]
-                 [seancorfield/next.jdbc "1.0.10"]
+                 [org.postgresql/postgresql "42.2.9"]
+                 [seancorfield/next.jdbc "1.0.11"]
                  [cheshire "5.9.0"]
                  [clj-time "0.15.2"]
                  [com.layerware/hugsql "0.5.1"]

--- a/project.clj
+++ b/project.clj
@@ -18,4 +18,5 @@
   :profiles {:dev
              {:dependencies [[org.clojure/tools.logging "0.5.0"]
                              [ch.qos.logback/logback-classic "1.2.3"]
+                             [nomnom/utility-belt "1.2.1"]
                              [com.stuartsierra/component "0.4.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nomnom/utility-belt.sql "0.3.0-SNAPSHOT"
+(defproject nomnom/utility-belt.sql "0.3.1-SNAPSHOT"
   :description "Tools for working with Postgres (queries, connection pool component, helpers etc)"
   :url "https://github.com/nomnom-insights/nomnom.utility-belt.sql"
   :deploy-repositories {"clojars" {:sign-releases false

--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
                                    :username :env/clojars_username
                                    :password :env/clojars_password}}
 
+  :warn-on-reflection true
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.postgresql/postgresql "42.2.9"]
                  [seancorfield/next.jdbc "1.0.11"]

--- a/script/start-test-postgres
+++ b/script/start-test-postgres
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+docker run --rm \
+       -p 5434:5432 \
+       -e POSTGRES_USER=utility_belt \
+       -e POSTGRES_PASSWORD=password \
+       -e POSTGRES_DB=utility_belt_test \
+       postgres:9.6

--- a/src/utility_belt/sql/component/connection_pool.clj
+++ b/src/utility_belt/sql/component/connection_pool.clj
@@ -4,7 +4,7 @@
             [next.jdbc.protocols :as jdbc.protocols]
             [com.stuartsierra.component :as component]))
 
-(defrecord HikariCP [config pool]
+(defrecord ConnectionPool [config datasource]
   component/Lifecycle
   (start [this]
     (log/infof "%s connecting=%s %s:%s"
@@ -13,22 +13,22 @@
                (:server-name config)
                (:port-number config))
     (let [pool (hikari/make-datasource config)]
-      (assoc this :pool pool)))
+      (assoc this :datasource pool)))
   (stop [this]
     (log/warnf "%s disconnecting=%s %s:%s"
                (:pool-name config)
                (:database-name config)
                (:server-name config)
                (:port-number config))
-    (when pool
-      (hikari/close-datasource pool))
-    (assoc this :pool nil))
+    (when datasource
+      (hikari/close-datasource datasource))
+    (assoc this :datasource nil))
   jdbc.protocols/Connectable
   (get-connection [this opts]
-    (:pool this))
+    (:datasource this))
   jdbc.protocols/Sourceable
   (get-datasource [this]
-    (:pool this)))
+    (:datasource this)))
 
 (defn create [config]
-  (map->HikariCP {:config config}))
+  (map->ConnectionPool {:config config}))

--- a/src/utility_belt/sql/component/connection_pool.clj
+++ b/src/utility_belt/sql/component/connection_pool.clj
@@ -12,7 +12,7 @@
                (:database-name config)
                (:server-name config)
                (:port-number config))
-      (let [pool (hikari/make-datasource config)]
+    (let [pool (hikari/make-datasource config)]
       (assoc this :pool pool)))
   (stop [this]
     (log/warnf "%s disconnecting=%s %s:%s"
@@ -28,8 +28,7 @@
     (:pool this))
   jdbc.protocols/Sourceable
   (get-datasource [this]
-    (:pool this))
-  )
+    (:pool this)))
 
 (defn create [config]
   (map->HikariCP {:config config}))

--- a/src/utility_belt/sql/conv.clj
+++ b/src/utility_belt/sql/conv.clj
@@ -1,4 +1,7 @@
 (ns utility-belt.sql.conv
+  )
+(comment
+  (comment
   (:require [clojure.java.jdbc :as jdbc]
             [cheshire.core :as json]
             [clj-time.coerce :as coerce])
@@ -59,3 +62,4 @@
       (if-let [elem-type (when type-name (second (re-find #"^_(.*)" type-name)))]
         (.setObject s i (.createArrayOf conn elem-type (to-array v)))
         (.setObject s i (jdbc/sql-value v))))))
+)

--- a/src/utility_belt/sql/conv.clj
+++ b/src/utility_belt/sql/conv.clj
@@ -1,17 +1,14 @@
 (ns utility-belt.sql.conv
-  (:require [next.jdbc :as jdbc]
-            [next.jdbc.result-set :as jdbc.result-set]
+  (:require [next.jdbc.result-set :as jdbc.result-set]
             [next.jdbc.prepare :as jdbc.prepare]
             [cheshire.core :as json]
-            [clj-time.coerce :as coerce]
-            [clojure.tools.logging :as log])
+            [clj-time.coerce :as coerce])
   (:import (clojure.lang IPersistentMap IPersistentVector)
            (org.postgresql.util PGobject)
            (org.joda.time DateTime)
            (java.util Date)
            (java.sql PreparedStatement)
            (org.postgresql.jdbc PgArray)))
-
 
 (extend-protocol jdbc.result-set/ReadableColumn
   PgArray
@@ -26,12 +23,10 @@
         "jsonb" (json/parse-string value true)
         value))))
 
-
 (defn value-to-json-pgobject [value]
-    (doto (PGobject.)
+  (doto (PGobject.)
     (.setType "jsonb")
     (.setValue (json/generate-string value))))
-
 
 (extend-protocol jdbc.prepare/SettableParameter
   Date

--- a/src/utility_belt/sql/conv.clj
+++ b/src/utility_belt/sql/conv.clj
@@ -1,65 +1,42 @@
 (ns utility-belt.sql.conv
-  )
-(comment
-  (comment
-  (:require [clojure.java.jdbc :as jdbc]
+  (:require [next.jdbc :as jdbc]
+            [next.jdbc.result-set :as jdbc.result-set]
+            [next.jdbc.prepare :as jdbc.prepare]
             [cheshire.core :as json]
-            [clj-time.coerce :as coerce])
-  (:import (org.postgresql.util PGobject)
+            [clj-time.coerce :as coerce]
+            [clojure.tools.logging :as log])
+  (:import (clojure.lang IPersistentMap IPersistentVector)
+           (org.postgresql.util PGobject)
            (java.sql PreparedStatement)
            (org.postgresql.jdbc PgArray)))
 
-(extend-protocol jdbc/IResultSetReadColumn
-  org.postgresql.jdbc.PgArray
-  (result-set-read-column [val metadata _]
-    (vec (.getArray val)))
 
-  ;; When reading JSONB, parse it out to clojure structure
+(extend-protocol jdbc.result-set/ReadableColumn
+  PgArray
+  (result-read-column-by-index [val _meta _idx]
+    (vec (.getArray val)))
   PGobject
-  (result-set-read-column [pgobj metadata idx]
-    (let [type  (.getType ^PGobject pgobj)
-          value (.getValue ^PGobject pgobj)]
+  (read-column-by-index [val _meta _idx]
+    (let [type  (.getType ^PGobject val)
+          value (.getValue ^PGobject val)]
       (case type
         "json" (json/parse-string value true)
         "jsonb" (json/parse-string value true)
-        value)))
-  ;; When reading timestamp, parse it out to java datetime
-  java.sql.Timestamp
-  (result-set-read-column [pgobj metadata idx]
-    (coerce/to-date-time pgobj)))
+        value))))
 
 
 (defn value-to-json-pgobject [value]
-  (doto (PGobject.)
+    (doto (PGobject.)
     (.setType "jsonb")
     (.setValue (json/generate-string value))))
 
-(extend-protocol jdbc/ISQLValue
-  ;; When inserting clojure structure convert it to JSONB
-  clojure.lang.IPersistentMap
-  (sql-value [value] (value-to-json-pgobject value))
-  clojure.lang.IPersistentVector
-  (sql-value [value] (value-to-json-pgobject value))
-  ;; When inserting datetime convert it to sql timestamp
-  org.joda.time.DateTime
-  (sql-value [value]
-    (coerce/to-sql-time value)))
 
-(extend-protocol jdbc/ISQLParameter
-  clojure.lang.IPersistentVector
-  (set-parameter [v ^PreparedStatement s ^long i]
-    ;; Adapted from
-    ;; https://github.com/remodoy/clj-postgresql/blob/78a3d11376f0991d92e6faf7d0287ed74df3521e/src/clj_postgresql/types.clj#L133
-    ;; Get the current connection and get the parameter's metadata
-    ;; so we can inspect the type expected by psql
-    (let [conn (.getConnection s)
-          meta (.getParameterMetaData s)
-          type-name (.getParameterTypeName meta i)]
-      ;; if we found a type, remove the underscore so we match a native type
-      ;; and create an array of elem-type
-      ;; otherwise fallback to original implementation of clojure.java.jdbc
-      ;; https://github.com/clojure/java.jdbc/blob/master/src/main/clojure/clojure/java/jdbc.clj#L471
-      (if-let [elem-type (when type-name (second (re-find #"^_(.*)" type-name)))]
-        (.setObject s i (.createArrayOf conn elem-type (to-array v)))
-        (.setObject s i (jdbc/sql-value v))))))
-)
+(extend-protocol jdbc.prepare/SettableParameter
+  IPersistentMap
+  (set-parameter [value statement idx]
+    (.setObject ^PreparedStatement statement idx
+                (value-to-json-pgobject value)))
+  IPersistentVector
+  (set-parameter [value statement idx]
+    (.setObject ^PreparedStatement statement idx
+                (value-to-json-pgobject value))))

--- a/src/utility_belt/sql/conv.clj
+++ b/src/utility_belt/sql/conv.clj
@@ -7,6 +7,8 @@
             [clojure.tools.logging :as log])
   (:import (clojure.lang IPersistentMap IPersistentVector)
            (org.postgresql.util PGobject)
+           (org.joda.time DateTime)
+           (java.util Date)
            (java.sql PreparedStatement)
            (org.postgresql.jdbc PgArray)))
 
@@ -32,6 +34,14 @@
 
 
 (extend-protocol jdbc.prepare/SettableParameter
+  Date
+  (set-parameter [value statement idx]
+    (.setTimestamp ^PreparedStatement statement idx
+                   (coerce/to-sql-time value)))
+  DateTime
+  (set-parameter [value statement idx]
+    (.setTimestamp ^PreparedStatement statement idx
+                   (coerce/to-sql-time value)))
   IPersistentMap
   (set-parameter [value statement idx]
     (.setObject ^PreparedStatement statement idx

--- a/src/utility_belt/sql/helpers.clj
+++ b/src/utility_belt/sql/helpers.clj
@@ -2,6 +2,10 @@
   (:require [next.jdbc]))
 
 (defmacro with-transaction
-  "Wrapper around jdbc transaction macro"
+  "Wrapper around jdbc transaction macro. Cleans up imports basically"
   [binding & body]
   `(next.jdbc/with-transaction ~binding ~@body))
+
+(defn execute [connection statement]
+  {:pre [(vector? statement)]}
+  (next.jdbc/execute! connection statement))

--- a/src/utility_belt/sql/helpers.clj
+++ b/src/utility_belt/sql/helpers.clj
@@ -1,13 +1,16 @@
 (ns utility-belt.sql.helpers
-  (:require [next.jdbc]))
+  (:require [next.jdbc]
+            [utility-belt.sql.model :as model]
+            ))
 
 (defmacro with-transaction
   "Wrapper around jdbc transaction macro. Cleans up imports basically"
   [binding & body]
   `(next.jdbc/with-transaction ~binding ~@body))
 
-;; TODO: Maybe inline this with with settings in `sql.model` and
-;; default to as-unaqilified-lower-maps
-(defn execute [connection statement]
-  {:pre [(vector? statement)]}
-  (next.jdbc/execute! connection statement))
+(defn execute
+  ([connection statement]
+   (execute connection statement :kebab-maps))
+ ([connection statement mode]
+  (next.jdbc/execute! connection statement
+                      (get model/modes mode))))

--- a/src/utility_belt/sql/helpers.clj
+++ b/src/utility_belt/sql/helpers.clj
@@ -9,7 +9,7 @@
 
 (defn execute
   ([connection statement]
-   (execute connection statement :kebab-maps))
-  ([connection statement mode]
+   (execute connection statement {:mode :kebab-maps}))
+  ([connection statement {:keys [mode]}]
    (next.jdbc/execute! connection statement
                        (get model/modes mode))))

--- a/src/utility_belt/sql/helpers.clj
+++ b/src/utility_belt/sql/helpers.clj
@@ -6,6 +6,8 @@
   [binding & body]
   `(next.jdbc/with-transaction ~binding ~@body))
 
+;; TODO: Maybe inline this with with settings in `sql.model` and
+;; default to as-unaqilified-lower-maps
 (defn execute [connection statement]
   {:pre [(vector? statement)]}
   (next.jdbc/execute! connection statement))

--- a/src/utility_belt/sql/helpers.clj
+++ b/src/utility_belt/sql/helpers.clj
@@ -1,7 +1,7 @@
 (ns utility-belt.sql.helpers
-  (:require [clojure.java.jdbc :as jdbc]))
+  (:require [next.jdbc]))
 
 (defmacro with-transaction
   "Wrapper around jdbc transaction macro"
   [binding & body]
-  `(jdbc/with-db-transaction ~binding ~@body))
+  `(next.jdbc/with-transaction ~binding ~@body))

--- a/src/utility_belt/sql/helpers.clj
+++ b/src/utility_belt/sql/helpers.clj
@@ -1,7 +1,6 @@
 (ns utility-belt.sql.helpers
   (:require [next.jdbc]
-            [utility-belt.sql.model :as model]
-            ))
+            [utility-belt.sql.model :as model]))
 
 (defmacro with-transaction
   "Wrapper around jdbc transaction macro. Cleans up imports basically"
@@ -11,6 +10,6 @@
 (defn execute
   ([connection statement]
    (execute connection statement :kebab-maps))
- ([connection statement mode]
-  (next.jdbc/execute! connection statement
-                      (get model/modes mode))))
+  ([connection statement mode]
+   (next.jdbc/execute! connection statement
+                       (get model/modes mode))))

--- a/src/utility_belt/sql/model.clj
+++ b/src/utility_belt/sql/model.clj
@@ -1,18 +1,37 @@
 (ns utility-belt.sql.model
   (:require [hugsql.core :as hugsql]
+            [clojure.tools.logging :as log]
+            [clojure.string :as str]
             [next.jdbc.result-set :as result-set]
             [hugsql.adapter.next-jdbc :as next-adapter]))
 
+(defn to-kebab [^String s]
+  (str/replace s #"_" "-"))
+
+(defn as-kebab-maps [rs opts]
+  (result-set/as-unqualified-modified-maps rs (assoc opts :qualifier-fn to-kebab :label-fn to-kebab)))
+
+(def modes
+  {;; compatible with clojure.java.jdbc
+   :java.jdbc {:builder-fn result-set/as-unqualified-lower-maps}
+   ;; new style - with qualified keywords
+   :next.jdbc {:builder-fn result-set/as-maps}
+   ;; like clojure.java.jdbc but column names are converted to kebab-case symbols
+   :kebab-maps {:builder-fn as-kebab-maps}})
+
 (defn load-sql-file
   "Loads given SQL file and injects db function definitions into current namespace"
-  [file]
-  (hugsql/def-db-fns file
-    {:adapter (next-adapter/hugsql-adapter-next-jdbc
-               {:builder-fn  result-set/as-unqualified-lower-maps})}))
+  ([file]
+   (load-sql-file file {:mode :java.jdbc}))
+  ([file {:keys [mode]}]
+   (hugsql/def-db-fns file
+     {:adapter (next-adapter/hugsql-adapter-next-jdbc
+                (get modes mode))})))
 
 (defn load-sql-file-vec-fns
   "Loads given SQL file and injects debug versions of db functions.
   Functions get a `-sqlvec` suffix and can be used to debug what sort of query
-  will be generated without actually running it."
+  will be generated without actually running it.
+  You can also pass it to JDBC functions for querying if that's your thing."
   [file]
   (hugsql/def-sqlvec-fns file))

--- a/src/utility_belt/sql/model.clj
+++ b/src/utility_belt/sql/model.clj
@@ -1,12 +1,14 @@
 (ns utility-belt.sql.model
   (:require [hugsql.core :as hugsql]
+            [next.jdbc.result-set :as result-set]
             [hugsql.adapter.next-jdbc :as next-adapter]))
 
 (defn load-sql-file
   "Loads given SQL file and injects db function definitions into current namespace"
   [file]
   (hugsql/def-db-fns file
-    {:adapter (next-adapter/hugsql-adapter-next-jdbc)}))
+    {:adapter (next-adapter/hugsql-adapter-next-jdbc
+               {:builder-fn  result-set/as-unqualified-lower-maps})}))
 
 (defn load-sql-file-vec-fns
   "Loads given SQL file and injects debug versions of db functions.

--- a/src/utility_belt/sql/model.clj
+++ b/src/utility_belt/sql/model.clj
@@ -1,12 +1,11 @@
 (ns utility-belt.sql.model
   (:require [hugsql.core :as hugsql]
             [clojure.tools.logging :as log]
-            [clojure.string :as str]
             [next.jdbc.result-set :as result-set]
             [hugsql.adapter.next-jdbc :as next-adapter]))
 
 (defn to-kebab [^String s]
-  (str/replace s #"_" "-"))
+  (.replaceAll s "_" "-"))
 
 (defn as-kebab-maps [rs opts]
   (result-set/as-unqualified-modified-maps rs (assoc opts :qualifier-fn to-kebab :label-fn to-kebab)))

--- a/src/utility_belt/sql/model.clj
+++ b/src/utility_belt/sql/model.clj
@@ -1,12 +1,12 @@
 (ns utility-belt.sql.model
   (:require [hugsql.core :as hugsql]
-            [hugsql.adapter.clojure-java-jdbc :as adapter]))
+            [hugsql.adapter.next-jdbc :as next-adapter]))
 
 (defn load-sql-file
   "Loads given SQL file and injects db function definitions into current namespace"
   [file]
   (hugsql/def-db-fns file
-    {:adapter (adapter/hugsql-adapter-clojure-java-jdbc)}))
+    {:adapter (next-adapter/hugsql-adapter-next-jdbc)}))
 
 (defn load-sql-file-vec-fns
   "Loads given SQL file and injects debug versions of db functions.

--- a/test/utility_belt/sql/connection.clj
+++ b/test/utility_belt/sql/connection.clj
@@ -1,0 +1,19 @@
+(ns utility-belt.sql.connection
+  (:require [utility-belt.sql.component.connection-pool :as cp]))
+
+(def connection-spec
+  {:pool-name  "test"
+   :adapter "postgresql"
+   :username (or (System/getenv "PG_USER") "utility_belt")
+   :password (or (System/getenv "PG_PASSWORD") "password")
+   :server-name  (or (System/getenv "PG_HOST") "127.0.0.1")
+   :port-number (Integer/parseInt (or (System/getenv "PG_PORT") "5434"))
+   :maximum-pool-size 10
+   :database-name (or (System/getenv "PG_DB") "utility_belt_test")})
+
+
+(defn start! [conn-atom]
+  (reset! conn-atom (.start (cp/create connection-spec))))
+
+(defn stop! [conn-atom]
+  (.stop @conn-atom))

--- a/test/utility_belt/sql/connection.clj
+++ b/test/utility_belt/sql/connection.clj
@@ -11,7 +11,6 @@
    :maximum-pool-size 10
    :database-name (or (System/getenv "PG_DB") "utility_belt_test")})
 
-
 (defn start! [conn-atom]
   (reset! conn-atom (.start (cp/create connection-spec))))
 

--- a/test/utility_belt/sql/core_test.clj
+++ b/test/utility_belt/sql/core_test.clj
@@ -94,10 +94,7 @@
     (add* tx {:name "yest"
               :email "test@test.com"
               :attributes {:bar 1
-                           :foo [:a
-                                 :b
-                                 :c]}
-
+                           :foo [:a :b :c]}
               :confirmed_at #inst "2019-02-03"})
     (add* tx {:name "who"
               :email "dat@test.com"
@@ -125,3 +122,20 @@
                (ex-message e)))))
     (testing "first insert should be cancelled"
       (is (= 2 (count (get-all* @conn)))))))
+
+(deftest raw-execute
+  (add* @conn {:name "yest"
+               :email "test@test.com"
+               :attributes {:bar 1
+                            :foo [:a :b :c]}
+               :confirmed_at #inst "2019-02-03"})
+  (is (= [{:people/attributes {:bar 1 :foo ["a" "b" "c"]}
+           :people/confirmed_at #inst "2019-02-03"
+           :people/email "test@test.com"
+           :people/name "yest"}]
+         (map
+          #(dissoc %
+                   :people/id
+                   :people/created_at
+                   :people/updated_at)
+          (helpers/execute @conn ["select * from people"])))))

--- a/test/utility_belt/sql/core_test.clj
+++ b/test/utility_belt/sql/core_test.clj
@@ -10,7 +10,7 @@
    :username (or (System/getenv "PG_USER") "utility_belt")
    :password (or (System/getenv "PG_PASSWORD") "password")
    :server-name  (or (System/getenv "PG_HOST") "127.0.0.1")
-   :port-number "5432"
+   :port-number "5434"
    :maximum-pool-size 10
    :database-name (or (System/getenv "PG_DB") "utility_belt_test")})
 

--- a/test/utility_belt/sql/core_test.clj
+++ b/test/utility_belt/sql/core_test.clj
@@ -24,38 +24,44 @@
   (is (= [] (people/get-all* @conn)))
   (is (=  [{:name "yest"
             :email "test@test.com"
+            :entity-id  #uuid "92731758-98f9-4358-974b-b15c74c917d9"
             :attributes {:bar 1
                          :foo ["a" "b" "c" "92731758-98f9-4358-974b-b15c74c917d9"]}
             :confirmed-at #inst "2019-06-24"}]
           (people/add* @conn {:name "yest"
                               :email "test@test.com"
+                              :entity-id  #uuid "92731758-98f9-4358-974b-b15c74c917d9"
                               :attributes {:bar 1
                                            :foo [:a :b :c #uuid "92731758-98f9-4358-974b-b15c74c917d9"]}
                               :confirmed-at (time/->date-time "2019-06-24")})))
   (is (= [{:name "who"
            :email "dat@test.com"
-           :attributes
-           {:bar 1
-            :foo {:ok "dawg"}}
+           :entity-id  #uuid "92731758-98f9-4358-974b-b15c74c917d0"
+           :attributes {:bar 1
+                        :foo {:ok "dawg"}}
            :confirmed-at #inst "2018-03-12T00:13:24Z"}]
          (people/add* @conn {:name "who"
                              :email "dat@test.com"
+                             :entity-id  #uuid "92731758-98f9-4358-974b-b15c74c917d0"
                              :attributes {:bar 1
                                           :foo {:ok :dawg}}
                              :confirmed-at #inst "2018-03-12T00:13:24Z"})))
   (is (= [{:name "who"
            :email "dat@test.com"
+           :entity-id  #uuid "92731758-98f9-4358-974b-b15c74c917d0"
            :attributes {:bar 1
                         :foo {:ok "dawg"}}
            :confirmed-at #inst  "2018-03-12T00:13:24Z"}
           {:name "yest"
            :email "test@test.com"
+           :entity-id  #uuid "92731758-98f9-4358-974b-b15c74c917d9"
            :attributes {:bar 1
                         :foo ["a" "b" "c"  "92731758-98f9-4358-974b-b15c74c917d9"]}
            :confirmed-at #inst "2019-06-24"}]
          (people/get-all* @conn)))
   (is (= [{:name "yest"
            :email "test@test.com"
+           :entity-id  #uuid "92731758-98f9-4358-974b-b15c74c917d9"
            :attributes {:bar 1
                         :foo ["a" "b" "c"  "92731758-98f9-4358-974b-b15c74c917d9"]}
            :confirmed-at #inst "2019-06-24"}]

--- a/test/utility_belt/sql/core_test.clj
+++ b/test/utility_belt/sql/core_test.clj
@@ -25,14 +25,12 @@
   (is (=  [{:name "yest"
             :email "test@test.com"
             :attributes {:bar 1
-                         :foo ["a" "b" "c"]}
+                         :foo ["a" "b" "c" "92731758-98f9-4358-974b-b15c74c917d9"]}
             :confirmed-at #inst "2019-06-24"}]
           (people/add* @conn {:name "yest"
                               :email "test@test.com"
                               :attributes {:bar 1
-                                           :foo [:a
-                                                 :b
-                                                 :c]}
+                                           :foo [:a :b :c #uuid "92731758-98f9-4358-974b-b15c74c917d9"]}
                               :confirmed-at (time/->date-time "2019-06-24")})))
   (is (= [{:name "who"
            :email "dat@test.com"
@@ -53,13 +51,13 @@
           {:name "yest"
            :email "test@test.com"
            :attributes {:bar 1
-                        :foo ["a" "b" "c"]}
+                        :foo ["a" "b" "c"  "92731758-98f9-4358-974b-b15c74c917d9"]}
            :confirmed-at #inst "2019-06-24"}]
          (people/get-all* @conn)))
   (is (= [{:name "yest"
            :email "test@test.com"
            :attributes {:bar 1
-                        :foo ["a" "b" "c"]}
+                        :foo ["a" "b" "c"  "92731758-98f9-4358-974b-b15c74c917d9"]}
            :confirmed-at #inst "2019-06-24"}]
          (people/get-all* @conn {:email "test@test.com"})))
   (is (= 1

--- a/test/utility_belt/sql/core_test.clj
+++ b/test/utility_belt/sql/core_test.clj
@@ -108,7 +108,7 @@
       (is (= 0 (count (get-all* @conn)))))
     (is (= 2 (count (get-all* tx)))))
   (is (= 2 (count (get-all* @conn))))
-  (testing "failing within transaction - should not aadd rows"
+  (testing "failing within transaction - should not aad rows if an exception is throwna"
     (try
       (helpers/with-transaction [tx @conn]
         (add* tx {:name "yest"

--- a/test/utility_belt/sql/core_test.clj
+++ b/test/utility_belt/sql/core_test.clj
@@ -62,10 +62,10 @@
                         :foo ["a" "b" "c"]}
            :confirmed-at #inst "2019-06-24"}]
          (people/get-all* @conn {:email "test@test.com"})))
-  (is (= {:next.jdbc/update-count 1}
+  (is (= 1
          (people/set-email* @conn {:old-email "test@test.com"
                                    :new-email "test2@test.com"})))
-  (is (= {:next.jdbc/update-count 1}
+  (is (= 1
          (people/delete* @conn {:email "dat@test.com"})))
   (is (= {:count 1}
          (people/count-all* @conn))))

--- a/test/utility_belt/sql/core_test.clj
+++ b/test/utility_belt/sql/core_test.clj
@@ -1,72 +1,50 @@
 (ns utility-belt.sql.core-test
   (:require [clojure.test :refer :all]
+            ;; -- test helpers
+            [utility-belt.sql.connection :as connection]
+            [utility-belt.sql.people :as people]
+            ;; -- actual things under test
             [utility-belt.time :as time]
             [utility-belt.sql.conv]
-            [utility-belt.sql.component.connection-pool :as cp]
             [utility-belt.sql.helpers :as helpers]
             [utility-belt.sql.model :as model]))
 
-(def connection-spec
-  {:pool-name  "test"
-   :adapter "postgresql"
-   :username (or (System/getenv "PG_USER") "utility_belt")
-   :password (or (System/getenv "PG_PASSWORD") "password")
-   :server-name  (or (System/getenv "PG_HOST") "127.0.0.1")
-   :port-number (Integer/parseInt (or (System/getenv "PG_PORT") "5434"))
-   :maximum-pool-size 10
-   :database-name (or (System/getenv "PG_DB") "utility_belt_test")})
-
-(model/load-sql-file "utility_belt/sql/people.sql" {:mode :kebab-maps})
-
 (def conn (atom nil))
 
-(defn start-conn! []
-  (reset! conn (.start (cp/create connection-spec))))
-
-(defn stop-conn! []
-  (.stop @conn))
-
-(defn reset-db! []
-  (start-conn!)
-  (next.jdbc/execute! @conn ["drop table people"])
-  (stop-conn!))
-
 (use-fixtures :each (fn [test-fn]
-                      (start-conn!)
+                      (connection/start! conn)
                       (try
-                        (setup* @conn)
-                        (delete-all* @conn)
+                        (people/setup* @conn)
+                        (people/delete-all* @conn)
                         (test-fn)
                         (finally
-                          (stop-conn!)))))
+                          (connection/stop! conn)))))
 
 (deftest crud-operations
-  (is (= [] (get-all* @conn)))
+  (is (= [] (people/get-all* @conn)))
   (is (=  [{:name "yest"
             :email "test@test.com"
             :attributes {:bar 1
                          :foo ["a" "b" "c"]}
             :confirmed-at #inst "2019-06-24"}]
-          (add* @conn {:name "yest"
-
-                       :email "test@test.com"
-
-                       :attributes {:bar 1
-                                    :foo [:a
-                                          :b
-                                          :c]}
-                       :confirmed-at (time/->date-time "2019-06-24")})))
+          (people/add* @conn {:name "yest"
+                              :email "test@test.com"
+                              :attributes {:bar 1
+                                           :foo [:a
+                                                 :b
+                                                 :c]}
+                              :confirmed-at (time/->date-time "2019-06-24")})))
   (is (= [{:name "who"
            :email "dat@test.com"
            :attributes
            {:bar 1
             :foo {:ok "dawg"}}
            :confirmed-at #inst "2018-03-12T00:13:24Z"}]
-         (add* @conn {:name "who"
-                      :email "dat@test.com"
-                      :attributes {:bar 1
-                                   :foo {:ok :dawg}}
-                      :confirmed-at (time/->date-time "2018-03-12T00:13:24Z")})))
+         (people/add* @conn {:name "who"
+                             :email "dat@test.com"
+                             :attributes {:bar 1
+                                          :foo {:ok :dawg}}
+                             :confirmed-at #inst "2018-03-12T00:13:24Z"})))
   (is (= [{:name "who"
            :email "dat@test.com"
            :attributes {:bar 1
@@ -77,68 +55,17 @@
            :attributes {:bar 1
                         :foo ["a" "b" "c"]}
            :confirmed-at #inst "2019-06-24"}]
-         (get-all* @conn)))
+         (people/get-all* @conn)))
   (is (= [{:name "yest"
            :email "test@test.com"
            :attributes {:bar 1
                         :foo ["a" "b" "c"]}
            :confirmed-at #inst "2019-06-24"}]
-         (get-all* @conn {:email "test@test.com"})))
+         (people/get-all* @conn {:email "test@test.com"})))
   (is (= {:next.jdbc/update-count 1}
-         (set-email* @conn {:old-email "test@test.com"
-                            :new-email "test2@test.com"})))
+         (people/set-email* @conn {:old-email "test@test.com"
+                                   :new-email "test2@test.com"})))
   (is (= {:next.jdbc/update-count 1}
-         (delete* @conn {:email "dat@test.com"})))
+         (people/delete* @conn {:email "dat@test.com"})))
   (is (= {:count 1}
-         (count-all* @conn))))
-
-(deftest transaction-operation
-  (helpers/with-transaction [tx @conn]
-    (add* tx {:name "yest"
-              :email "test@test.com"
-              :attributes {:bar 1
-                           :foo [:a :b :c]}
-              :confirmed-at #inst "2019-02-03"})
-    (add* tx {:name "who"
-              :email "dat@test.com"
-              :attributes {:bar 1
-                           :foo {:ok :dawg}}
-              :confirmed-at #inst "2019-02-03"})
-    (testing  "tx not finished yet so using db-pool no results should be reutnred"
-      (is (= 0 (count (get-all* @conn)))))
-    (is (= 2 (count (get-all* tx)))))
-  (is (= 2 (count (get-all* @conn))))
-  (testing "failing within transaction - should not aad rows if an exception is throwna"
-    (try
-      (helpers/with-transaction [tx @conn]
-        (add* tx {:name "yest"
-                  :email "test@test.com"
-                  :confirmed-at #inst "2019-02-03"
-                  :attributes {:bar 1
-                               :foo [:a :b :c]}})
-        (add* tx {:name nil
-                  :email "dat@test.com"
-                  :attributes {:bar 1
-                               :foo {:ok :dawg}}}))
-      (catch Exception e
-        (is (= "Parameter Mismatch: :confirmed-at parameter data not found."
-               (ex-message e)))))
-    (testing "first insert should be cancelled"
-      (is (= 2 (count (get-all* @conn)))))))
-
-(deftest raw-execute
-  (add* @conn {:name "yest"
-               :email "test@test.com"
-               :attributes {:bar 1
-                            :foo [:a :b :c]}
-               :confirmed-at #inst "2019-02-03"})
-  (is (= [{:people/attributes {:bar 1 :foo ["a" "b" "c"]}
-           :people/confirmed_at #inst "2019-02-03"
-           :people/email "test@test.com"
-           :people/name "yest"}]
-         (map
-          #(dissoc %
-                   :people/id
-                   :people/created_at
-                   :people/updated_at)
-          (helpers/execute @conn ["select * from people"])))))
+         (people/count-all* @conn))))

--- a/test/utility_belt/sql/helpers_test.clj
+++ b/test/utility_belt/sql/helpers_test.clj
@@ -73,3 +73,45 @@
                  (ex-message e))))))
     (testing "No new data should be inserted"
       (is (= 2 (count (people/get-all* @conn)))))))
+
+(deftest modes-test
+  (people/add* @conn {:name "yest"
+                      :email "test@test.com"
+                      :confirmed-at #inst "2019-02-03"
+                      :attributes {:bar 1
+                                   :foo [:a :b :c]}})
+  (people/add* @conn {:name "yest2"
+                      :email "test2@test.com"
+                      :confirmed-at #inst "2019-02-03"
+                      :attributes {:bar 1
+                                   :foo [:a :b :c]}})
+  (testing "default - kebab-maps"
+    (is (= [{:attributes {:bar 1, :foo ["a" "b" "c"]},
+             :confirmed-at #inst "2019-02-03T00:00:00.000000000-00:00",
+             :email "test@test.com",
+             :name "yest"}
+            {:attributes {:bar 1, :foo ["a" "b" "c"]},
+             :confirmed-at #inst "2019-02-03T00:00:00.000000000-00:00",
+             :email "test2@test.com",
+             :name "yest2"}]
+           (helpers/execute @conn ["select attributes, confirmed_at, email, name  from people"]))))
+  (testing "next.jdbc"
+    (is (= [{:people/attributes {:bar 1, :foo ["a" "b" "c"]},
+             :people/confirmed_at #inst "2019-02-03T00:00:00.000000000-00:00",
+             :people/email "test@test.com",
+             :people/name "yest"}
+            {:people/attributes {:bar 1, :foo ["a" "b" "c"]},
+             :people/confirmed_at #inst "2019-02-03T00:00:00.000000000-00:00",
+             :people/email "test2@test.com",
+             :people/name "yest2"}]
+           (helpers/execute @conn ["select attributes, confirmed_at, email, name  from people"] {:mode :next.jdbc}))))
+  (testing "clojure.java.jdbc"
+    (is (= [{:attributes {:bar 1, :foo ["a" "b" "c"]},
+             :confirmed_at #inst "2019-02-03T00:00:00.000000000-00:00",
+             :email "test@test.com",
+             :name "yest"}
+            {:attributes {:bar 1, :foo ["a" "b" "c"]},
+             :confirmed_at #inst "2019-02-03T00:00:00.000000000-00:00",
+             :email "test2@test.com",
+             :name "yest2"}]
+           (helpers/execute @conn ["select attributes, confirmed_at, email, name  from people"] {:mode :java.jdbc})))))

--- a/test/utility_belt/sql/helpers_test.clj
+++ b/test/utility_belt/sql/helpers_test.clj
@@ -23,10 +23,12 @@
 (deftest raw-execute
   (people/add* @conn {:name "yest"
                       :email "test@test.com"
+                      :entity-id  #uuid "92731758-98f9-4358-974b-b15c74c917d9"
                       :attributes {:bar 1
                                    :foo [:a :b :c]}
                       :confirmed-at #inst "2019-02-03"})
   (is (= [{:attributes {:bar 1 :foo ["a" "b" "c"]}
+           :entity-id  #uuid "92731758-98f9-4358-974b-b15c74c917d9"
            :confirmed-at #inst "2019-02-03"
            :email "test@test.com"
            :name "yest"}]
@@ -41,11 +43,13 @@
   (helpers/with-transaction [tx @conn]
     (people/add* tx {:name "yest"
                      :email "test@test.com"
+                     :entity-id  #uuid "92731758-98f9-4358-974b-b15c74c917d9"
                      :attributes {:bar 1
                                   :foo [:a :b :c]}
                      :confirmed-at #inst "2019-02-03"})
     (people/add* tx {:name "who"
                      :email "dat@test.com"
+                     :entity-id  #uuid "92731758-98f9-4358-974b-b15c74c917d9"
                      :attributes {:bar 1
                                   :foo {:ok :dawg}}
                      :confirmed-at #inst "2019-02-03"})
@@ -60,6 +64,7 @@
     (helpers/with-transaction [tx @conn {:rollback-only true}]
       (people/add* tx {:name "yest"
                        :email "test@test.com"
+                       :entity-id  #uuid "92731758-98f9-4358-974b-b15c74c917d9"
                        :confirmed-at #inst "2019-02-03"
                        :attributes {:bar 1
                                     :foo [:a :b :c]}})
@@ -77,11 +82,13 @@
 (deftest modes-test
   (people/add* @conn {:name "yest"
                       :email "test@test.com"
+                      :entity-id  #uuid "92731758-98f9-4358-974b-b15c74c917d9"
                       :confirmed-at #inst "2019-02-03"
                       :attributes {:bar 1
                                    :foo [:a :b :c]}})
   (people/add* @conn {:name "yest2"
                       :email "test2@test.com"
+                      :entity-id  #uuid "92731758-98f9-4358-974b-b15c74c917d9"
                       :confirmed-at #inst "2019-02-03"
                       :attributes {:bar 1
                                    :foo [:a :b :c]}})

--- a/test/utility_belt/sql/helpers_test.clj
+++ b/test/utility_belt/sql/helpers_test.clj
@@ -26,15 +26,15 @@
                       :attributes {:bar 1
                                    :foo [:a :b :c]}
                       :confirmed-at #inst "2019-02-03"})
-  (is (= [{:people/attributes {:bar 1 :foo ["a" "b" "c"]}
-           :people/confirmed_at #inst "2019-02-03"
-           :people/email "test@test.com"
-           :people/name "yest"}]
+  (is (= [{:attributes {:bar 1 :foo ["a" "b" "c"]}
+           :confirmed-at #inst "2019-02-03"
+           :email "test@test.com"
+           :name "yest"}]
          (map
           #(dissoc %
-                   :people/id
-                   :people/created_at
-                   :people/updated_at)
+                   :id
+                   :created-at
+                   :updated-at)
           (helpers/execute @conn ["select * from people"])))))
 
 (deftest transaction-operation

--- a/test/utility_belt/sql/helpers_test.clj
+++ b/test/utility_belt/sql/helpers_test.clj
@@ -51,9 +51,12 @@
                      :confirmed-at #inst "2019-02-03"})
     (testing  "tx not finished yet so using db-pool no results should be reutnred"
       (is (= 0 (count (people/get-all* @conn)))))
-    (is (= 2 (count (people/get-all* tx)))))
-  (is (= 2 (count (people/get-all* @conn))))
-  (testing "failing within transaction - should not aad rows if an exception is throwna"
+    (testing "when reading via transaction, we get the correct result"
+      (is (= 2 (count (people/get-all* tx))))))
+  (testing "tx is done, we can read via normal conn:"
+    (is (= 2 (count (people/get-all* @conn)))))
+
+  (testing "failing within transaction - should not add rows if an exception is thrown during transaction"
     (helpers/with-transaction [tx @conn {:rollback-only true}]
       (people/add* tx {:name "yest"
                        :email "test@test.com"
@@ -68,5 +71,5 @@
         (catch Exception e
           (is (= "Parameter Mismatch: :confirmed-at parameter data not found."
                  (ex-message e))))))
-    (testing "first insert should be cancelled"
+    (testing "No new data should be inserted"
       (is (= 2 (count (people/get-all* @conn)))))))

--- a/test/utility_belt/sql/helpers_test.clj
+++ b/test/utility_belt/sql/helpers_test.clj
@@ -1,0 +1,73 @@
+(ns utility-belt.sql.helpers-test
+  (:require [clojure.test :refer :all]
+            ;; -- test helpers
+            [utility-belt.sql.connection :as connection]
+            [utility-belt.sql.people :as people]
+            ;; -- actual things under test
+            [utility-belt.time :as time]
+            [utility-belt.sql.conv]
+            [utility-belt.sql.helpers :as helpers]
+            [utility-belt.sql.model :as model]))
+
+(def conn (atom nil))
+
+(use-fixtures :each (fn [test-fn]
+                      (connection/start! conn)
+                      (try
+                        (people/setup* @conn)
+                        (people/delete-all* @conn)
+                        (test-fn)
+                        (finally
+                          (connection/stop! conn)))))
+
+(deftest raw-execute
+  (people/add* @conn {:name "yest"
+                      :email "test@test.com"
+                      :attributes {:bar 1
+                                   :foo [:a :b :c]}
+                      :confirmed-at #inst "2019-02-03"})
+  (is (= [{:people/attributes {:bar 1 :foo ["a" "b" "c"]}
+           :people/confirmed_at #inst "2019-02-03"
+           :people/email "test@test.com"
+           :people/name "yest"}]
+         (map
+          #(dissoc %
+                   :people/id
+                   :people/created_at
+                   :people/updated_at)
+          (helpers/execute @conn ["select * from people"])))))
+
+
+(deftest transaction-operation
+  (helpers/with-transaction [tx @conn]
+    (people/add* tx {:name "yest"
+                     :email "test@test.com"
+                     :attributes {:bar 1
+                                  :foo [:a :b :c]}
+                     :confirmed-at #inst "2019-02-03"})
+    (people/add* tx {:name "who"
+                     :email "dat@test.com"
+                     :attributes {:bar 1
+                                  :foo {:ok :dawg}}
+                     :confirmed-at #inst "2019-02-03"})
+    (testing  "tx not finished yet so using db-pool no results should be reutnred"
+      (is (= 0 (count (people/get-all* @conn)))))
+    (is (= 2 (count (people/get-all* tx)))))
+  (is (= 2 (count (people/get-all* @conn))))
+  (testing "failing within transaction - should not aad rows if an exception is throwna"
+    (try
+      (helpers/with-transaction [tx @conn]
+        (people/add* tx {:name "yest"
+                         :email "test@test.com"
+                         :confirmed-at #inst "2019-02-03"
+                         :attributes {:bar 1
+                                      :foo [:a :b :c]}})
+        (people/add* tx {:name nil
+                         :email "dat@test.com"
+                         :attributes {:bar 1
+                                      :foo {:ok :dawg}}}))
+      (catch Exception e
+        (is (= "Parameter Mismatch: :confirmed-at parameter data not found."
+               (ex-message e)))))
+    (testing "first insert should be cancelled"
+      (is (= 2 (count (people/get-all* @conn)))))))

--- a/test/utility_belt/sql/people.clj
+++ b/test/utility_belt/sql/people.clj
@@ -1,5 +1,4 @@
 (ns utility-belt.sql.people
   (:require [utility-belt.sql.model :as model]))
 
-
 (model/load-sql-file "utility_belt/sql/people.sql" {:mode :kebab-maps})

--- a/test/utility_belt/sql/people.clj
+++ b/test/utility_belt/sql/people.clj
@@ -1,0 +1,5 @@
+(ns utility-belt.sql.people
+  (:require [utility-belt.sql.model :as model]))
+
+
+(model/load-sql-file "utility_belt/sql/people.sql" {:mode :kebab-maps})

--- a/test/utility_belt/sql/people.sql
+++ b/test/utility_belt/sql/people.sql
@@ -18,16 +18,26 @@ select name, email, attributes, confirmed_at from people
 --~ (when (:email params) "where email = :email")
 order by id desc;
 
+-- :name count-all* :? :1
+select count(*) from people
+
 -- :name add* :<!
 insert into people
 ( name, email, attributes, updated_at, confirmed_at)
 values
-(:name, :email, CAST(:attributes AS jsonb), current_timestamp, :confirmed_at)
+(:name, :email, CAST(:attributes AS jsonb), current_timestamp, :confirmed-at)
 returning name, email, attributes, confirmed_at
+
+-- :name set-email* :! :1
+update people
+set email = :new-email
+where email = :old-email
+
 
 -- :name delete* :! :1
 delete from people
 where email = :email
+
 
 -- :name delete-all* :! :*
 truncate people

--- a/test/utility_belt/sql/people.sql
+++ b/test/utility_belt/sql/people.sql
@@ -6,21 +6,24 @@ create table if not exists people (
 id serial primary key,
 name text not null,
 email text not null,
-attributes jsonb
+attributes jsonb,
+created_at timestamp default current_timestamp,
+updated_at timestamp default current_timestamp,
+confirmed_at timestamp
 )
 
 -- :name get-all* :? :*
-select name, email, attributes from people
+select name, email, attributes, confirmed_at from people
 
 --~ (when (:email params) "where email = :email")
 order by id desc;
 
 -- :name add* :<!
 insert into people
-( name, email, attributes)
+( name, email, attributes, updated_at, confirmed_at)
 values
-(:name, :email, CAST(:attributes AS jsonb))
-returning name, email, attributes
+(:name, :email, CAST(:attributes AS jsonb), current_timestamp, :confirmed_at)
+returning name, email, attributes, confirmed_at
 
 -- :name delete* :! :1
 delete from people

--- a/test/utility_belt/sql/people.sql
+++ b/test/utility_belt/sql/people.sql
@@ -28,13 +28,13 @@ values
 (:name, :email, CAST(:attributes AS jsonb), current_timestamp, :confirmed-at)
 returning name, email, attributes, confirmed_at
 
--- :name set-email* :! :1
+-- :name set-email* :! :n
 update people
 set email = :new-email
 where email = :old-email
 
 
--- :name delete* :! :1
+-- :name delete* :! :n
 delete from people
 where email = :email
 

--- a/test/utility_belt/sql/people.sql
+++ b/test/utility_belt/sql/people.sql
@@ -6,6 +6,7 @@ create table if not exists people (
 id serial primary key,
 name text not null,
 email text not null,
+entity_id uuid default uuid_generate_v4(),
 attributes jsonb,
 created_at timestamp default current_timestamp,
 updated_at timestamp default current_timestamp,
@@ -13,7 +14,7 @@ confirmed_at timestamp
 )
 
 -- :name get-all* :? :*
-select name, email, attributes, confirmed_at from people
+select name, email, attributes, confirmed_at, entity_id from people
 
 --~ (when (:email params) "where email = :email")
 order by id desc;
@@ -23,10 +24,10 @@ select count(*) from people
 
 -- :name add* :<!
 insert into people
-( name, email, attributes, updated_at, confirmed_at)
+( name, email, attributes, updated_at, confirmed_at, entity_id)
 values
-(:name, :email, CAST(:attributes AS jsonb), current_timestamp, :confirmed-at)
-returning name, email, attributes, confirmed_at
+(:name, :email, CAST(:attributes AS jsonb), current_timestamp, :confirmed-at, :entity-id)
+returning name, email, attributes, confirmed_at, entity_id
 
 -- :name set-email* :! :n
 update people

--- a/test/utility_belt/sql/people.sql
+++ b/test/utility_belt/sql/people.sql
@@ -1,4 +1,7 @@
 -- :name setup* :!
+create extension if not exists "hstore";
+create extension if not exists "uuid-ossp";
+
 create table if not exists people (
 id serial primary key,
 name text not null,


### PR DESCRIPTION
- [x] Make the HikariCP component work with how jdbc.next uses connections/datasources
- [x] jdbc.next settings (namespaced keywords etc)
- [x] PG coercions 
- [x] timestamp/datetime support
- [x] "modes" - emulate old clojure.java.jdbc behavior (e.g. return an int on update/insert) or "new" mode
- [x] column name coercion and transformation (snake case to kebab case, for both inserts and reads)

---

I found an interesting problem with transactions. Here's the original test, using `clojure.java.jdbc`:

https://github.com/nomnom-insights/nomnom.utility-belt.sql/blob/67ba3afc047804509cff44c8c8ec206799b9d0c8/test/utility_belt/sql/core_test.clj#L53-L57

In that test - an exception is thrown *and caught* within the transaction, and the result is as expected - none of the inserts are applied.

In `jdbc.next` version, catching the exception within the transaction **will make the first insert statement work**:

https://github.com/nomnom-insights/nomnom.utility-belt.sql/blob/47a656d12d736bb07161ad2eeed5ad1db8be0be2/test/utility_belt/sql/core_test.clj#L112-L125

This might impact on our own code, so we will have to review transaction usage before upgrading.

### Update to the above :point_up: 

Turns out old transaction behavior can be restored by passing extra flag to the transaction macro:

https://github.com/nomnom-insights/nomnom.utility-belt.sql/blob/b8f68bbbf03eaef04847b5b069ab4c7db1ccb476/test/utility_belt/sql/helpers_test.clj#L56-L72
