### PR TITLE
Feature: transaction utils

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,8 @@
                  [clj-time "0.15.2"]
                  [com.layerware/hugsql "0.5.1"]
                  [com.layerware/hugsql-adapter-next-jdbc "0.5.1" :exclusions [seancorfield/next.jdbc]]
-                 [hikari-cp "2.13.0"]]
+                 [hikari-cp "2.13.0" :exclusions [com.zaxxer/HikariCP]]
+                 [com.zaxxer/HikariCP "4.0.3"]]
   :plugins [[lein-cloverage "1.1.1" :exclusions [org.clojure/clojure]]]
   :profiles {:dev
              {:dependencies [[org.clojure/tools.logging "1.1.0"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nomnom/utility-belt.sql "1.0.1"
+(defproject nomnom/utility-belt.sql "1.1.0-SNAPSHOT"
   :description "Tools for working with Postgres (queries, connection pool component, helpers etc)"
   :url "https://github.com/nomnom-insights/nomnom.utility-belt.sql"
   :deploy-repositories {"clojars" {:sign-releases false
@@ -7,8 +7,8 @@
 
   :warn-on-reflection true
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [org.postgresql/postgresql "42.2.23"]
-                 [com.github.seancorfield/next.jdbc "1.2.689"]
+                 [org.postgresql/postgresql "42.3.1"]
+                 [com.github.seancorfield/next.jdbc "1.2.753"]
                  [cheshire "5.10.1"]
                  [clj-time "0.15.2"]
                  [com.layerware/hugsql "0.5.1"]
@@ -17,6 +17,6 @@
   :plugins [[lein-cloverage "1.1.1" :exclusions [org.clojure/clojure]]]
   :profiles {:dev
              {:dependencies [[org.clojure/tools.logging "1.1.0"]
-                             [ch.qos.logback/logback-classic "1.2.5"]
+                             [ch.qos.logback/logback-classic "1.2.7"]
                              [nomnom/utility-belt "1.3.1"]
                              [com.stuartsierra/component "1.0.0"]]}})

--- a/src/utility_belt/sql/component/connection_pool.clj
+++ b/src/utility_belt/sql/component/connection_pool.clj
@@ -1,8 +1,10 @@
 (ns utility-belt.sql.component.connection-pool
-  (:require [hikari-cp.core :as hikari]
-            [clojure.tools.logging :as log]
-            [next.jdbc.protocols :as jdbc.protocols]
-            [com.stuartsierra.component :as component]))
+  (:require
+    [clojure.tools.logging :as log]
+    [com.stuartsierra.component :as component]
+    [hikari-cp.core :as hikari]
+    [next.jdbc.protocols :as jdbc.protocols]))
+
 
 (defrecord ConnectionPool [config datasource]
   component/Lifecycle
@@ -29,6 +31,7 @@
   jdbc.protocols/Sourceable
   (get-datasource [this]
     (:datasource this)))
+
 
 (defn create [config]
   (map->ConnectionPool {:config config}))

--- a/src/utility_belt/sql/conv.clj
+++ b/src/utility_belt/sql/conv.clj
@@ -9,7 +9,8 @@
       IPersistentMap
       IPersistentVector)
     (java.sql
-      PreparedStatement Timestamp)
+      PreparedStatement
+      Timestamp)
     (java.util
       Date)
     (org.joda.time
@@ -40,6 +41,7 @@
   (read-column-by-index [val _meta _idx]
     (coerce/to-date-time val)))
 
+
 (defn value-to-json-pgobject [value]
   (doto (PGobject.)
     (.setType "jsonb")
@@ -61,10 +63,10 @@
                 (value-to-json-pgobject value)))
   IPersistentVector
   (set-parameter [v ^PreparedStatement s ^long i]
-   (let [conn (.getConnection s)
+    (let [conn (.getConnection s)
           meta (.getParameterMetaData s)
           type-name (.getParameterTypeName meta i)]
-     (if-let [elem-type (when type-name (second (re-find #"^_(.*)" type-name)))]
-       (.setObject s i (.createArrayOf conn elem-type (to-array v)))
-       (.setObject ^PreparedStatement s i
-                   (value-to-json-pgobject v))))))
+      (if-let [elem-type (when type-name (second (re-find #"^_(.*)" type-name)))]
+        (.setObject s i (.createArrayOf conn elem-type (to-array v)))
+        (.setObject ^PreparedStatement s i
+                    (value-to-json-pgobject v))))))

--- a/src/utility_belt/sql/helpers.clj
+++ b/src/utility_belt/sql/helpers.clj
@@ -5,7 +5,12 @@
 
 
 (defmacro with-transaction
-  "Wrapper around jdbc transaction macro. Cleans up imports basically"
+  "Wrapper around jdbc transaction macro.   Cleans up imports so we always use ut.sql
+  Suports the same options, eg.
+  [tx conn]
+  and
+  [tx conn opts]
+  + body."
   [binding & body]
   `(next.jdbc/with-transaction ~binding ~@body))
 

--- a/src/utility_belt/sql/helpers.clj
+++ b/src/utility_belt/sql/helpers.clj
@@ -1,11 +1,14 @@
 (ns utility-belt.sql.helpers
-  (:require [next.jdbc]
-            [utility-belt.sql.model :as model]))
+  (:require
+    [next.jdbc]
+    [utility-belt.sql.model :as model]))
+
 
 (defmacro with-transaction
   "Wrapper around jdbc transaction macro. Cleans up imports basically"
   [binding & body]
   `(next.jdbc/with-transaction ~binding ~@body))
+
 
 (defn execute
   ([connection statement]
@@ -13,3 +16,11 @@
   ([connection statement {:keys [mode]}]
    (next.jdbc/execute! connection statement
                        (get model/modes mode))))
+
+
+(defn transaction?
+  "Detects if passed in data source is a transaction or not.
+  NOTE: this only works with HikariCP managed connections/transactions and the connection pool
+  defined in utility-belt.sql.component.connection-pool"
+  [tx-or-conn]
+  (-> tx-or-conn bean :transactionIsolation number?))

--- a/src/utility_belt/sql/model.clj
+++ b/src/utility_belt/sql/model.clj
@@ -1,14 +1,18 @@
 (ns utility-belt.sql.model
-  (:require [hugsql.core :as hugsql]
-            [clojure.tools.logging :as log]
-            [next.jdbc.result-set :as result-set]
-            [hugsql.adapter.next-jdbc :as next-adapter]))
+  (:require
+    [clojure.tools.logging :as log]
+    [hugsql.adapter.next-jdbc :as next-adapter]
+    [hugsql.core :as hugsql]
+    [next.jdbc.result-set :as result-set]))
+
 
 (defn to-kebab [^String s]
   (.replaceAll s "_" "-"))
 
+
 (defn as-kebab-maps [rs opts]
   (result-set/as-unqualified-modified-maps rs (assoc opts :qualifier-fn to-kebab :label-fn to-kebab)))
+
 
 (def modes
   {;; compatible with clojure.java.jdbc
@@ -18,14 +22,16 @@
    ;; like clojure.java.jdbc but column names are converted to kebab-case symbols
    :kebab-maps {:builder-fn as-kebab-maps}})
 
+
 (defn load-sql-file
   "Loads given SQL file and injects db function definitions into current namespace"
   ([file]
    (load-sql-file file {:mode :java.jdbc}))
   ([file {:keys [mode]}]
    (hugsql/def-db-fns file
-     {:adapter (next-adapter/hugsql-adapter-next-jdbc
-                (get modes mode))})))
+                      {:adapter (next-adapter/hugsql-adapter-next-jdbc
+                                  (get modes mode))})))
+
 
 (defn load-sql-file-vec-fns
   "Loads given SQL file and injects debug versions of db functions.

--- a/test/utility_belt/sql/connection.clj
+++ b/test/utility_belt/sql/connection.clj
@@ -1,5 +1,7 @@
 (ns utility-belt.sql.connection
-  (:require [utility-belt.sql.component.connection-pool :as cp]))
+  (:require
+    [utility-belt.sql.component.connection-pool :as cp]))
+
 
 (def connection-spec
   {:pool-name  "test"
@@ -11,8 +13,10 @@
    :maximum-pool-size 10
    :database-name (or (System/getenv "PG_NAME") "test")})
 
+
 (defn start! [conn-atom]
   (reset! conn-atom (.start (cp/create connection-spec))))
+
 
 (defn stop! [conn-atom]
   (.stop @conn-atom))

--- a/test/utility_belt/sql/core_test.clj
+++ b/test/utility_belt/sql/core_test.clj
@@ -1,13 +1,13 @@
 (ns utility-belt.sql.core-test
   (:require
+    [clj-time.coerce :as coerce]
     [clojure.test :refer [deftest is use-fixtures]]
     ;; -- test helpers
     [utility-belt.sql.connection :as connection]
     [utility-belt.sql.conv]
     [utility-belt.sql.people :as people]
     ;; -- actual things under test
-    [utility-belt.time :as time]
-    [clj-time.coerce :as coerce]))
+    [utility-belt.time :as time]))
 
 
 (def conn (atom nil))

--- a/test/utility_belt/sql/helpers_test.clj
+++ b/test/utility_belt/sql/helpers_test.clj
@@ -1,14 +1,17 @@
 (ns utility-belt.sql.helpers-test
-  (:require [clojure.test :refer :all]
+  (:require
+    [clj-time.coerce :as coerce]
+    [clojure.test :refer [deftest testing is use-fixtures]]
     ;; -- test helpers
-            [utility-belt.sql.connection :as connection]
-            [utility-belt.sql.people :as people]
+    [utility-belt.sql.connection :as connection]
     ;; -- actual things under test
-            [utility-belt.sql.conv]
-            [utility-belt.sql.helpers :as helpers]
-            [clj-time.coerce :as coerce]))
+    [utility-belt.sql.conv]
+    [utility-belt.sql.helpers :as helpers]
+    [utility-belt.sql.people :as people]))
+
 
 (def conn (atom nil))
+
 
 (use-fixtures :each (fn [test-fn]
                       (connection/start! conn)
@@ -20,6 +23,7 @@
                         (test-fn)
                         (finally
                           (connection/stop! conn)))))
+
 
 (deftest raw-execute
   (people/add* @conn {:name "yest"
@@ -34,32 +38,40 @@
            :email "test@test.com"
            :name "yest"}]
          (map
-          #(dissoc %
-                   :id
-                   :created-at
-                   :updated-at)
-          (helpers/execute @conn ["select * from people"])))))
+           #(dissoc %
+                    :id
+                    :created-at
+                    :updated-at)
+           (helpers/execute @conn ["select * from people"])))))
+
 
 (deftest transaction-operation
-  (helpers/with-transaction [tx @conn]
-    (people/add* tx {:name "yest"
-                     :email "test@test.com"
-                     :entity-id  #uuid "92731758-98f9-4358-974b-b15c74c917d9"
-                     :attributes {:bar 1
-                                  :foo [:a :b :c]}
-                     :confirmed-at #inst "2019-02-03"})
-    (people/add* tx {:name "who"
-                     :email "dat@test.com"
-                     :entity-id  #uuid "92731758-98f9-4358-974b-b15c74c917d9"
-                     :attributes {:bar 1
-                                  :foo {:ok :dawg}}
-                     :confirmed-at #inst "2019-02-03"})
-    (testing  "tx not finished yet so using db-pool no results should be reutnred"
-      (is (= 0 (count (people/get-all* @conn)))))
-    (testing "when reading via transaction, we get the correct result"
-      (is (= 2 (count (people/get-all* tx))))))
-  (testing "tx is done, we can read via normal conn:"
-    (is (= 2 (count (people/get-all* @conn)))))
+  (testing "detecting transactions"
+    (helpers/with-transaction [tx @conn]
+      (is (true? (helpers/transaction? tx)))
+      ;; need to run something to avoid "connection closed" error
+      (helpers/execute tx ["select * from now()"]))
+    (is (false? (helpers/transaction? @conn))))
+  (testing "operations in a transaction"
+    (helpers/with-transaction [tx @conn]
+      (people/add* tx {:name "yest"
+                       :email "test@test.com"
+                       :entity-id  #uuid "92731758-98f9-4358-974b-b15c74c917d9"
+                       :attributes {:bar 1
+                                    :foo [:a :b :c]}
+                       :confirmed-at #inst "2019-02-03"})
+      (people/add* tx {:name "who"
+                       :email "dat@test.com"
+                       :entity-id  #uuid "92731758-98f9-4358-974b-b15c74c917d9"
+                       :attributes {:bar 1
+                                    :foo {:ok :dawg}}
+                       :confirmed-at #inst "2019-02-03"})
+      (testing  "tx not finished yet so using db-pool no results should be reutnred"
+        (is (= 0 (count (people/get-all* @conn)))))
+      (testing "when reading via transaction, we get the correct result"
+        (is (= 2 (count (people/get-all* tx))))))
+    (testing "tx is done, we can read via normal conn:"
+      (is (= 2 (count (people/get-all* @conn))))))
 
   (testing "failing within transaction - should not add rows if an exception is thrown during transaction"
     (helpers/with-transaction [tx @conn {:rollback-only true}]
@@ -79,6 +91,7 @@
                  (ex-message e))))))
     (testing "No new data should be inserted"
       (is (= 2 (count (people/get-all* @conn)))))))
+
 
 (deftest modes-test
   (people/add* @conn {:name "yest"

--- a/test/utility_belt/sql/helpers_test.clj
+++ b/test/utility_belt/sql/helpers_test.clj
@@ -47,7 +47,7 @@
 
 (deftest transaction-operation
   (testing "detecting transactions"
-    (helpers/with-transaction [tx @conn]
+    (helpers/with-transaction [tx @conn {:read-only true}]
       (is (true? (helpers/transaction? tx)))
       ;; need to run something to avoid "connection closed" error
       (helpers/execute tx ["select * from now()"]))


### PR DESCRIPTION
- Updates all dependencies, including HikariCP and Postgres driver
- Adds a convenience function to detect if given object is a connection or a proxy used in a transaction
  - tests for the above

Released as https://clojars.org/nomnom/utility-belt.sql/versions/1.1.0-SNAPSHOT

`[nomnom/utility-belt.sql "1.1.0-SNAPSHOT"]`